### PR TITLE
The line length is specified as 120 in the doc

### DIFF
--- a/rules/style.js
+++ b/rules/style.js
@@ -125,13 +125,16 @@ module.exports = {
 
     // specify the maximum length of a line in your program
     // http://eslint.org/docs/rules/max-len
-    'max-len': ['error', 100, 2, {
+    'max-len': ['error', {
+      code: 120,
+      tabWidth: 2,
       ignoreUrls: true,
       ignoreComments: false,
-//      ignoreRegExpLiterals: true,
+      ignoreRegExpLiterals: true,
       ignoreStrings: true,
       ignoreTemplateLiterals: true
     }],
+
     // specify the max number of lines in a file
     // http://eslint.org/docs/rules/max-lines
     'max-lines': ['off', {


### PR DESCRIPTION
This limit should not apply to strings, URLS, or regular expressions.
Also I updated to the current syntax of eslint.