### PR TITLE
Engines strict

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
   - v7
+  - v6
+  - v4
 script:
   - npm test

--- a/package.json
+++ b/package.json
@@ -25,5 +25,9 @@
   "devDependencies": {
     "eslint": "^3.10.0",
     "mocha": "^3.1.2"
+  },
+  "engineStrict": true,
+  "engines": {
+    "node": ">=4"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -59,7 +59,6 @@ describe('Bad Lint', () => {
 
   it('should notice extra spaces', () => {
     const report = new eslint.CLIEngine().executeOnText('var a = 4  + 3;');
-    console.dir(report.results[0].messages);
     expectReport(report).contains('no-multi-spaces');
   });
 


### PR DESCRIPTION
Add strict checking of nodejs version. eslint is not strict so you can end up getting syntax error when running old version of node.js (0.10.6)
```
/usr/lib/node_modules/eslint/bin/eslint.js:16
const useStdIn = (process.argv.indexOf("--stdin") > -1),
^^^^^
SyntaxError: Use of const in strict mode.
at Module._compile (module.js:439:25)
at Object.Module._extensions..js (module.js:474:10)
at Module.load (module.js:356:32)
at Function.Module._load (module.js:312:12)
at Function.Module.runMain (module.js:497:10)
at startup (node.js:119:16)
at node.js:906:3
```