### PR TITLE
Fix the quote properties rule to be more lenient.

### DIFF
--- a/rules/style.js
+++ b/rules/style.js
@@ -306,7 +306,7 @@ module.exports = {
 
     // require quotes around object literal property names
     // http://eslint.org/docs/rules/quote-props.html
-    'quote-props': ['error', 'as-needed', { keywords: false, unnecessary: true, numbers: false }],
+    'quote-props': ['error', 'as-needed', { keywords: true, unnecessary: false, numbers: false }],
 
     // specify whether double or single quotes should be used
     quotes: ['error', 'single', { avoidEscape: true }],

--- a/test/good/sample.js
+++ b/test/good/sample.js
@@ -16,4 +16,24 @@ function fizzBuzz(n) {
   }
 }
 
+// Using always quotes.
+var object1 = {
+  'bad': true,
+  'indent-size': 2,
+  'with space': true,
+  'break': 'yes',
+  '42': ['life', 'universe', 'everything']
+};
+
+// Only using necessary quotes
+var object2 = {
+  bad: true,
+  'indent-size': 2,
+  'with space': true,
+  'break': 'yes',
+  42: ['life', 'universe', 'everything']
+};
+
 fizzBuzz(20);
+console.log(object1);
+console.log(object2);

--- a/test/test.js
+++ b/test/test.js
@@ -68,4 +68,10 @@ describe('Bad Lint', () => {
       'asjdhkjsahdkjaksjdh) {\n    return 2;\n}\n');
     expectReport(report).contains('max-len');
   });
+
+  it('should require quotes around keywords in object property names', () => {
+    const report = new eslint.CLIEngine().executeOnText(
+      'var obj = { function: \'no\' }');
+    expectReport(report).contains('quote-props');
+  });
 });


### PR DESCRIPTION
/ref Code quality
/author harold.putman
/approvers @chazelex or @bryyoung 
/description Improve sanity of rule about quoting object properties.

It's OK to quote things that don't need quoted. But make sure that keywords are always quoted because IE 8 will fail on that. There's test code to make sure it works as intended too.
