### PR TITLE
Mixed operators

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-lexmarkweb",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "ESLint configuration for Lexmark Web Team",
   "main": "index.js",
   "scripts": {

--- a/rules/style.js
+++ b/rules/style.js
@@ -212,7 +212,7 @@ module.exports = {
         ['&&', '||'],
         ['in', 'instanceof']
       ],
-      allowSamePrecedence: false
+      allowSamePrecedence: true
     }],
 
     // disallow mixed spaces and tabs for indentation

--- a/test/good/sample.js
+++ b/test/good/sample.js
@@ -35,5 +35,8 @@ var object2 = {
 };
 
 fizzBuzz(20);
+var a = 4 + 3 - 2;
+var b = (4 * 7) - 1;
+console.log(a + b);
 console.log(object1);
 console.log(object2);


### PR DESCRIPTION
Allow `var a = 3 + 4 - 1;` without parens. Because we're wild like that. 🎉 
