### PR TITLE
Prevent Useless escape sequences in strings.

### DIFF
--- a/rules/style.js
+++ b/rules/style.js
@@ -261,6 +261,10 @@ module.exports = {
     // disallow dangling underscores in identifiers
     'no-underscore-dangle': ['error', { allowAfterThis: false }],
 
+
+    // disallow backslash escaping characters unnecessarily in string
+    'no-useless-escape': 'error',
+
     // disallow the use of Boolean literals in conditional expressions
     // also, prefer `a || b` over `a ? a : b`
     // http://eslint.org/docs/rules/no-unneeded-ternary

--- a/test/test.js
+++ b/test/test.js
@@ -74,4 +74,10 @@ describe('Bad Lint', () => {
       'var obj = { function: \'no\' }');
     expectReport(report).contains('quote-props');
   });
+
+  it('should flag useless escape characters', () => {
+    const report = new eslint.CLIEngine().executeOnText(
+      'var foo = \'This \\: is useless escape\';');
+    expectReport(report).contains('no-useless-escape');
+  });
 });


### PR DESCRIPTION
Why? Because I put '\:' in a string expecting to get two characters. I meant '\\:'