### PR TITLE
Ensure that block statements are wrapped in curly braces

### DIFF
--- a/rules/style.js
+++ b/rules/style.js
@@ -25,6 +25,9 @@ module.exports = {
     // enforces consistent naming when capturing the current execution context
     'consistent-this': 'off',
 
+    // ensure that block statements are wrapped in curly braces
+    'curly': 'error',
+
     // enforce newline at the end of file, with no multiple empty lines
     'eol-last': ['error', 'always'],
 

--- a/test/test.js
+++ b/test/test.js
@@ -74,4 +74,10 @@ describe('Bad Lint', () => {
       'var obj = { function: \'no\' }');
     expectReport(report).contains('quote-props');
   });
+
+  it('should require curly braces always', () => {
+    const report = new eslint.CLIEngine().executeOnText(
+      'if (foo) foo++;');
+    expectReport(report).contains('curly');
+  });
 });


### PR DESCRIPTION
Don't use this:
```
if (err) throw err;
```
Instead use this:
```
if (err) {
  throw err;
}
```